### PR TITLE
Statistics.md remove `scikits.statsmodels`

### DIFF
--- a/Statistics.md
+++ b/Statistics.md
@@ -55,7 +55,6 @@
 - [pystatsd](https://github.com/jsocol/pystatsd) :: A Python client for statsd. [Documentation](http://statsd.readthedocs.org/en/latest/index.html)
 - [SAMCNet](https://github.com/binarybana/samcnet) is a toolkit and demonstration for Bayesian model averaging over objective functions defined over model classes of interest using advanced MCMC techniques.
 - [Statsmodels](http://statsmodels.sourceforge.net) is a Python library package for econometrics, plotting functions, statistical modeling and tests, that provides a complement to SciPy for statistical computations including descriptive statistics, and estimation and inference for statistical models. [Source Code](https://github.com/statsmodels/statsmodels).
-- [Scikits-statsmodels](http://scikits.appspot.com/statsmodels) :: Statistical computations and models for use with SciPy. 
 
 ###### Resources
 - [Statistics and Data Mining with Open Source Tools](http://oswco.com/2013/mar/14/statistics-and-data-mining-open-source-tools/)


### PR DESCRIPTION
remove outdated `scikits.statsmodels`

This is an old version of `statsmodels` from before the rename and dropping of the `scikits` namespace.
